### PR TITLE
Set up CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up CMake
+        uses: jwlawson/actions-setup-cmake@v1
+        with:
+          cmake-version: '3.31.0-rc2'
+
+      - name: Configure CMake
+        run: cmake -S . -B build/release -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build/release --config Release
+
+      - name: Run Tests
+        run: ctest --test-dir build/release --output-on-failure


### PR DESCRIPTION
Set up CI pipeline to test only on Windows

- Configured GitHub Actions to run the CI pipeline exclusively on Windows.
- Removed macOS and Linux testing steps, as they are still in development.
- Updated CMake version to 3.31.0-rc2.
- Included steps for checking out code, configuring, building, and running tests.