### PR TITLE
Update CMake version to stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up CMake
         uses: jwlawson/actions-setup-cmake@v1
         with:
-          cmake-version: '3.31.0-rc2'
+          cmake-version: '3.31.0'
 
       - name: Configure CMake
         run: cmake -S . -B build/release -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Updated the GitHub Actions CI configuration to use CMake version 3.31.0 instead of the unavailable 3.31.0-rc2. This change ensures the CI pipeline can successfully set up the environment for building and testing the App Manager project.

- Modified the 'Set up CMake' step in the .github/workflows/ci.yml file to specify a stable CMake version.
- Ensured compatibility with the CI environment for future pushes and pull requests.